### PR TITLE
Add support for building xxHash 0.8.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,162 @@
+project(
+    'xxHash',
+    ['c'],
+    # library files are BSD licensed. xxhsum utility is GPL licensed.
+    license: ['BSD-2-Clause', 'GPL-2.0'],
+    version: '0.8.0',
+)
+
+cc = meson.get_compiler('c')
+
+force_memory_access = {
+    'attribute': 1,
+    'unaligned-reads': 2,
+    'byteshift': 3,
+}
+
+vector = {
+    'scalar': 'XXH_SCALAR',
+    'sse2': 'XXH_SSE2',
+    'avx2': 'XXH_AVX2',
+    'avx512': 'XXH_AVX512',
+    'neon': 'XXH_NEON',
+    'vsx': 'XXH_VSX',
+}
+
+c_args = []
+
+if get_option('inline-all')
+    c_args += '-DXXH_INLINE_ALL'
+endif
+
+if get_option('namespace') != ''
+    c_args += '-DXXH_NAMESPACE=@0@'.format(get_option('namespace'))
+endif
+
+if get_option('force-memory-access') != 'default'
+    c_args += '-DXXH_FORCE_MEMORY_ACCESS=@0@'.format(force_memory_access[get_option('force-memory-access')])
+endif
+
+if get_option('force-align-check')
+    c_args += '-DXXH_FORCE_ALIGN_CHECK'
+endif
+
+if get_option('vector') != 'default'
+    c_args += '-DXXH_VECTOR=@0@'.format(vector[get_option('vector')])
+endif
+
+if not get_option('prefetch')
+    c_args += '-DXXH_NO_PREFETCH'
+endif
+
+if get_option('prefetch-dist') > 0
+    c_args += '-DXXH_PREFETCH_DIST=@0@'.format(get_option('prefetch-dist'))
+endif
+
+if get_option('inline-hints')
+    c_args += '-DXXH_INLINE_HINTS'
+endif
+
+if get_option('reroll')
+    c_args += '-DXXH_REROLL'
+endif
+
+if get_option('accept-null-input-pointer')
+    c_args += '-DXXH_ACCEPT_NULL_INPUT_POINTER'
+endif
+
+if not get_option('long-long')
+    c_args += '-DXXH_NO_LONG_LONG'
+endif
+
+if get_option('cpu-little-endian').enabled()
+    c_args += '-DXXH_CPU_LITTLE_ENDIAN=1'
+elif get_option('cpu-little-endian').disabled()
+    c_args += '-DXXH_CPU_LITTLE_ENDIAN=0'
+endif
+
+if cc.get_id() == 'msvc' and get_option('default_library') != 'static'
+    c_args += 'XXH_IMPORT'
+endif
+
+pkgconfig_data = configuration_data({
+    'PREFIX': get_option('prefix'),
+    'EXECPREFIX': get_option('prefix'),
+    'INCLUDEDIR': get_option('includedir'),
+    'LIBDIR': get_option('libdir'),
+    'VERSION': meson.project_version(),
+})
+
+pkgconfig = configure_file(
+    input: 'libxxhash.pc.in',
+    output: 'libxxhash.pc',
+    configuration: pkgconfig_data,
+)
+
+install_data(
+    pkgconfig,
+    install_dir: get_option('prefix') / get_option('libdir') / 'pkgconfig'
+)
+
+inc = include_directories('.')
+
+xxhash = library(
+    'xxhash',
+    ['xxhash.c'],
+    version: meson.project_version(),
+    c_args: c_args,
+    include_directories: [
+        inc,
+    ],
+    install: true,
+)
+
+# For use is xxhsum only
+xxhash_internal_dep = declare_dependency(
+    link_with: xxhash,
+    compile_args: c_args,
+    include_directories: [
+        inc,
+    ],
+)
+
+if get_option('default_library') == 'static'
+    c_args += '-DXXH_STATIC_LINKING_ONLY'
+endif
+
+xxhash_dep = declare_dependency(
+    link_with: xxhash,
+    compile_args: c_args,
+    include_directories: [
+        inc,
+    ],
+)
+
+if get_option('cli')
+    install_man('xxhsum.1')
+
+    cli_c_args = []
+
+    cli_sources = [
+        files(
+            'xxhsum.c',
+        ),
+    ]
+
+    if get_option('dispatch')
+        cli_c_args += '-DXXH_DISPATCH'
+        cli_sources += files(
+            'xxh_x86dispatch.c',
+        )
+    endif
+
+    xxhsum = executable(
+        'xxhsum',
+        cli_sources,
+        c_args: cli_c_args,
+        dependencies: [
+            xxhash_internal_dep,
+        ],
+        install: true,
+    )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,27 @@
+option('cli', type: 'boolean', value: true, description: 'Build the CLI')
+option('inline-all', type: 'boolean', value: false,
+    description: 'Make all functions inline')
+option('namespace', type: 'string', value: '',
+    description: 'Prefixes all symbols with the value of XXH_NAMESPACE')
+option('force-memory-access', type: 'combo', choices: ['default', 'attribute', 'unaligned-reads', 'byteshift'],
+    value: 'default', description: 'See XXH_FORCE_MEMORY_ACCESS')
+option('force-align-check', type: 'boolean', value: false,
+    description: 'Use a faster direct read path when input is aligned')
+option('vector', type: 'combo', choices: ['default', 'scalar', 'sse2', 'avx2', 'avx512', 'neon', 'vsx'],
+    value: 'default', description: 'Manually select a vector instruction set')
+option('prefetch', type: 'boolean', value: true,
+    description: 'Disable prefetching. XXH3 only')
+option('prefetch-dist', type: 'integer', value: 0,
+    description: 'Select prefetching distance. XXH3 only')
+option('inline-hints', type: 'boolean', value: true,
+    description: 'See XXH_NO_INLINE_HINTS')
+option('reroll', type: 'boolean', value: false,
+    description: 'Reduces the size of the generated code by not unrolling some loops')
+option('accept-null-input-pointer', type: 'boolean', value: false,
+    description: 'Prevent dereferencing of a NULL pointer')
+option('long-long', type: 'boolean', value: true,
+    description: 'Include compilation of algorithms relying on 64-bit types')
+option('cpu-little-endian', type: 'feature', value: 'auto',
+    description: 'Force endianness')
+option('dispatch', type: 'boolean', value: false,
+    description: 'See DISPATCH=1 for information about xxh_x86dispatch.c')

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = xxHash-0.8.0
+
+source_url = https://github.com/Cyan4973/xxHash/archive/v0.8.0.tar.gz
+source_filename = xxHash-0.8.0.tar.gz
+source_hash = 7054c3ebd169c97b64a92d7b994ab63c70dd53a06974f1f630ab782c28db0f4f
+
+[provide]
+libxxhash = xxhash_dep


### PR DESCRIPTION
This greatly cleans up the work from the previous version and adds support for 0.8.0.